### PR TITLE
support antedeluvian C++ compilers

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -296,7 +296,7 @@ void HexabombRenderer::updatePlayerInfo(int currentTurnNumber,
     if (_isSuddenDeath)
     {
         // Sort traversal order by decreasing score.
-        std::sort(pInfoTravarsalOrder.begin(), pInfoTravarsalOrder.end(), std::greater());
+      std::sort(pInfoTravarsalOrder.begin(), pInfoTravarsalOrder.end(), std::greater<std::tuple<int,int,int>>());
     }
 
     // Update rendering data


### PR DESCRIPTION
Some academic curmudgeons use older c++ compilers which need some hints with templates (namely, g++ 7). This is support for said curmudgeons.